### PR TITLE
hanging } in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Edit *config.json* and enter the key and secret from https://trello.com/1/appKey
     "trello": {
       "key": "",
       "secret": ""
-   }
+    }
 
 ### Redis
 


### PR DESCRIPTION
Noticed the spacing was off on one of the code examples in the README. This fixes that.
